### PR TITLE
Avoid evolving basis twice

### DIFF
--- a/wmin/app.py
+++ b/wmin/app.py
@@ -11,6 +11,7 @@ wmin_providers = [
     "wmin.model",
     "wmin.utils",
     "wmin.basis",
+    "wmin.ultranest_fit",
 ]
 
 

--- a/wmin/config.py
+++ b/wmin/config.py
@@ -8,8 +8,12 @@ Config module of wmin
 import dill
 from validphys.core import PDF
 from wmin.model import WMinPDF
+import logging
+from reportengine.configparser import ConfigError
 
 from colibri.config import Environment, colibriConfig
+
+log = logging.getLogger(__name__)
 
 
 class Environment(Environment):
@@ -22,7 +26,9 @@ class WminConfig(colibriConfig):
     """
 
     def parse_prior_settings(self, settings):
-
+        """
+        Parse the prior settings for the wmin fit.
+        """
         if "type" not in settings.keys():
             raise ValueError("Missing key type for prior_settings")
 
@@ -34,6 +40,35 @@ class WminConfig(colibriConfig):
                 settings["min_val"] = -1
             if "max_val" not in settings.keys():
                 settings["max_val"] = 1
+
+        return settings
+
+    def parse_wmin_settings(self, settings):
+        """
+        Parse the wmin settings onto a dictionary.
+        """
+        known_keys = {"n_basis", "wminpdfset", "wmin_inherited_evolution"}
+
+        kdiff = settings.keys() - known_keys
+        for k in kdiff:
+            log.warning(
+                ConfigError(f"Key '{k}' in ns_settings not known.", k, known_keys)
+            )
+
+        wmin_settings = {}
+
+        # Set the ultranest seed
+        if "n_basis" not in settings.keys():
+            raise ValueError("Missing key n_basis for wmin_settings")
+        wmin_settings["n_basis"] = settings.get("n_basis")
+
+        if "wminpdfset" not in settings.keys():
+            raise ValueError("Missing key wminpdfset for wmin_settings")
+        wmin_settings["wminpdfset"] = settings.get("wminpdfset")
+
+        wmin_settings["wmin_inherited_evolution"] = settings.get(
+            "wmin_inherited_evolution", False
+        )
 
         return settings
 

--- a/wmin/config.py
+++ b/wmin/config.py
@@ -70,7 +70,7 @@ class WminConfig(colibriConfig):
             "wmin_inherited_evolution", False
         )
 
-        return settings
+        return wmin_settings
 
     def produce_pdf_model(self, wmin_settings, output_path, dump_model=True):
         """

--- a/wmin/export_results.py
+++ b/wmin/export_results.py
@@ -80,7 +80,7 @@ def write_new_lhapdf_info_file_from_previous_pdf(
                 out_stream.write(f'SetDesc: f"{description_set}"\n')
             elif l.find("NumMembers:") >= 0:
                 out_stream.write(f"NumMembers: {num_members}\n")
-            elif l.find("ErrorType: replicas") >= 0:
+            elif l.find("ErrorType:") >= 0:
                 out_stream.write(f"ErrorType: {errortype}\n")
             else:
                 out_stream.write(l)

--- a/wmin/export_results.py
+++ b/wmin/export_results.py
@@ -22,6 +22,71 @@ from validphys.core import PDF
 log = logging.getLogger(__name__)
 
 
+def write_wmin_combined_replicas(wmin_parameters, replicas_df, new_wmin_pdf):
+    """
+    Writes a new LHAPDF set from the results of an UltraNest fit.
+    The UltraNest fit must have been performed using a wmin parameterization so that the
+    new set can be written as a sum rule conserving linear combination of the replicas of
+    the basis set.
+
+    Parameters
+    ----------
+    wmin_parameters: Array
+        wmin parameters posterior samples, shape (n_posterior_samples, n_params)
+
+    replicas_df: DataFrame
+        DataFrame containing replicas of the basis set at all scales
+
+    new_wmin_pdf: Path
+        Path to the new wmin PDF set
+    """
+    n_params = wmin_parameters.shape[1]
+
+    for i, wmin_weight in enumerate(wmin_parameters):
+
+        wmin_centr_rep, replica = (
+            replicas_df.loc[:, [1]],
+            replicas_df.loc[:, range(2, n_params + 2)],
+        )
+
+        wm_replica = wmin_centr_rep.dot([1.0 - np.sum(wmin_weight)]) + replica.dot(
+            wmin_weight
+        )
+
+        wm_headers = f"PdfType: replica\nFormat: lhagrid1\nFromMCReplica: {i}\n"
+        log.info(f"Writing replica {i + 1} to {new_wmin_pdf}")
+        write_replica(i + 1, new_wmin_pdf, wm_headers.encode("UTF-8"), wm_replica)
+
+
+def write_new_lhapdf_info_file_from_previous_pdf(
+    path_old_pdfset,
+    name_old_pdfset,
+    path_new_pdfset,
+    name_new_pdfset,
+    num_members,
+    description_set="Weight-minimized set",
+    errortype="replicas",
+):
+    """
+    Writes a new LHAPDF set info file based on an existing set.
+    """
+
+    # write LHAPDF info file for a new pdf set
+    with open(path_old_pdfset / f"{name_old_pdfset}.info", "r") as in_stream, open(
+        path_new_pdfset / f"{name_new_pdfset}.info", "w"
+    ) as out_stream:
+        for l in in_stream.readlines():
+            if l.find("SetDesc:") >= 0:
+                out_stream.write(f'SetDesc: f"{description_set}"\n')
+            elif l.find("NumMembers:") >= 0:
+                out_stream.write(f"NumMembers: {num_members}\n")
+            elif l.find("ErrorType: replicas") >= 0:
+                out_stream.write(f"ErrorType: {errortype}\n")
+            else:
+                out_stream.write(l)
+    log.info(f"Info file written to {path_new_pdfset / f'{name_new_pdfset}.info'}")
+
+
 def write_lhapdf_from_ultranest_result(
     wmin_settings,
     ultranest_fit,
@@ -55,43 +120,24 @@ def write_lhapdf_from_ultranest_result(
         os.makedirs(new_wmin_pdf)
 
     # write LHAPDF info file for new wmin pdf set
-    with open(wmin_basis_pdf / f"{wminpdfset}.info", "r") as in_stream, open(
-        new_wmin_pdf / f"{wmin_fit_name}.info", "w"
-    ) as out_stream:
-        for l in in_stream.readlines():
-            if l.find("SetDesc:") >= 0:
-                out_stream.write(
-                    f'SetDesc: "Weight-minimized set using {wminpdfset} as basis"\n'
-                )
-            elif l.find("NumMembers:") >= 0:
-                out_stream.write(
-                    f"NumMembers: {ns_settings["n_posterior_samples"] + 1}\n"
-                )
-            elif l.find("ErrorType: replicas") >= 0:
-                out_stream.write(f"ErrorType: {errortype}\n")
-            else:
-                out_stream.write(l)
+    write_new_lhapdf_info_file_from_previous_pdf(
+        path_old_pdfset=wmin_basis_pdf,
+        name_old_pdfset=wminpdfset,
+        path_new_pdfset=new_wmin_pdf,
+        name_new_pdfset=wmin_fit_name,
+        num_members=ns_settings["n_posterior_samples"] + 1,
+        description_set=f"Weight-minimized set using {wminpdfset} as basis",
+        errortype=errortype,
+    )
 
     # load replicas from basis set at all scales
     headers, grids = load_all_replicas(wminpdfset)
     replicas_df = rep_matrix(grids)
-    n_params = len(ultranest_fit.param_names)
 
     wmin_parameters_sample = ultranest_fit.resampled_posterior
 
-    for i, wmin_weight in enumerate(wmin_parameters_sample):
-        wmin_centr_rep, replica = (
-            replicas_df.loc[:, [1]],
-            replicas_df.loc[:, range(2, n_params + 2)],
-        )
-
-        wm_replica = wmin_centr_rep.dot([1.0 - np.sum(wmin_weight)]) + replica.dot(
-            wmin_weight
-        )
-
-        wm_headers = f"PdfType: replica\nFormat: lhagrid1\nFromMCReplica: {i}\n"
-        log.info(f"Writing replica {i + 1} to {new_wmin_pdf}")
-        write_replica(i + 1, new_wmin_pdf, wm_headers.encode("UTF-8"), wm_replica)
+    # write replicas to new wmin pdf set
+    write_wmin_combined_replicas(wmin_parameters_sample, replicas_df, new_wmin_pdf)
 
     # Generate central replica
     log.info(f"Generating central replica for {new_wmin_pdf}")

--- a/wmin/export_results.py
+++ b/wmin/export_results.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 
 def write_lhapdf_from_ultranest_result(
-    wminpdfset,
+    wmin_settings,
     ultranest_fit,
     ns_settings,
     output_path,
@@ -38,7 +38,8 @@ def write_lhapdf_from_ultranest_result(
     ----------
 
     """
-    wminpdfset = PDF(wminpdfset)
+    wminpdfset = PDF(wmin_settings["wminpdfset"])
+
     lhapdf_path = pathlib.Path(lhapdf.paths()[-1])
 
     # path to pdf set that was used as a basis for the wmin fit
@@ -71,6 +72,7 @@ def write_lhapdf_from_ultranest_result(
             else:
                 out_stream.write(l)
 
+    # load replicas from basis set at all scales
     headers, grids = load_all_replicas(wminpdfset)
     replicas_df = rep_matrix(grids)
     n_params = len(ultranest_fit.param_names)
@@ -87,7 +89,6 @@ def write_lhapdf_from_ultranest_result(
             wmin_weight
         )
 
-        # for i, replica in tqdm(enumerate(result), total=len(weights)):
         wm_headers = f"PdfType: replica\nFormat: lhagrid1\nFromMCReplica: {i}\n"
         log.info(f"Writing replica {i + 1} to {new_wmin_pdf}")
         write_replica(i + 1, new_wmin_pdf, wm_headers.encode("UTF-8"), wm_replica)

--- a/wmin/export_results.py
+++ b/wmin/export_results.py
@@ -1,0 +1,90 @@
+"""
+wmin.export_results.py
+
+This module contains functions tailored for the export of fit results that are
+performed in the wmin parameterization.
+"""
+
+import pathlib
+import lhapdf
+import os
+import logging
+import numpy as np
+
+from validphys.lhio import load_all_replicas, rep_matrix, write_replica
+from validphys.core import PDF
+
+log = logging.getLogger(__name__)
+
+
+def write_lhapdf_from_ultranest_result(
+    wminpdfset,
+    ultranest_fit,
+    ns_settings,
+    output_path,
+    errortype: str = "replicas",
+):
+    """
+    Writes a new LHAPDF set from the results of an UltraNest fit.
+    The UltraNest fit must have been performed using a wmin parameterization so that the
+    new set can be written as a linear combination of the replicas of the basis set.
+
+    Parameters
+    ----------
+
+    """
+    wminpdfset = PDF(wminpdfset)
+    lhapdf_path = pathlib.Path(lhapdf.paths()[-1])
+
+    # path to pdf set that was used as a basis for the wmin fit
+    wmin_basis_pdf = lhapdf_path / str(wminpdfset)
+
+    wmin_fit_name = pathlib.Path(output_path).name
+
+    # path to new wmin pdf set
+    new_wmin_pdf = lhapdf_path / wmin_fit_name
+
+    # create new wmin pdf set folder in lhapdf path if it does not exist
+    if not new_wmin_pdf.exists():
+        os.makedirs(new_wmin_pdf)
+
+    # write LHAPDF info file for new wmin pdf set
+    with open(wmin_basis_pdf / f"{wminpdfset}.info", "r") as in_stream, open(
+        new_wmin_pdf / f"{wmin_fit_name}.info", "w"
+    ) as out_stream:
+        for l in in_stream.readlines():
+            if l.find("SetDesc:") >= 0:
+                out_stream.write(
+                    f'SetDesc: "Weight-minimized set using {wminpdfset} as basis"\n'
+                )
+            elif l.find("NumMembers:") >= 0:
+                out_stream.write(
+                    f"NumMembers: {ns_settings["n_posterior_samples"] + 1}\n"
+                )
+            elif l.find("ErrorType: replicas") >= 0:
+                out_stream.write(f"ErrorType: {errortype}\n")
+            else:
+                out_stream.write(l)
+
+    headers, grids = load_all_replicas(wminpdfset)
+    replicas_df = rep_matrix(grids)
+    n_params = len(ultranest_fit.param_names)
+
+    wmin_parameters_sample = ultranest_fit.resampled_posterior
+
+    for i, wmin_weight in enumerate(wmin_parameters_sample):
+        wmin_centr_rep, replica = (
+            replicas_df.loc[:, [1]],
+            replicas_df.loc[:, range(2, len(ultranest_fit.param_names) + 2)],
+        )
+
+        wm_replica = wmin_centr_rep.dot([1.0 - np.sum(wmin_weight)]) + replica.dot(
+            wmin_weight
+        )
+
+        # for i, replica in tqdm(enumerate(result), total=len(weights)):
+        wm_headers = f"PdfType: replica\nFormat: lhagrid1\nFromMCReplica: {i}\n"
+        log.info(f"Writing replica {i + 1} to {new_wmin_pdf}")
+        write_replica(i + 1, new_wmin_pdf, wm_headers.encode("UTF-8"), wm_replica)
+
+    # Generate central replica

--- a/wmin/export_results.py
+++ b/wmin/export_results.py
@@ -11,7 +11,12 @@ import os
 import logging
 import numpy as np
 
-from validphys.lhio import load_all_replicas, rep_matrix, write_replica
+from validphys.lhio import (
+    load_all_replicas,
+    rep_matrix,
+    write_replica,
+    generate_replica0,
+)
 from validphys.core import PDF
 
 log = logging.getLogger(__name__)
@@ -75,7 +80,7 @@ def write_lhapdf_from_ultranest_result(
     for i, wmin_weight in enumerate(wmin_parameters_sample):
         wmin_centr_rep, replica = (
             replicas_df.loc[:, [1]],
-            replicas_df.loc[:, range(2, len(ultranest_fit.param_names) + 2)],
+            replicas_df.loc[:, range(2, n_params + 2)],
         )
 
         wm_replica = wmin_centr_rep.dot([1.0 - np.sum(wmin_weight)]) + replica.dot(
@@ -88,3 +93,5 @@ def write_lhapdf_from_ultranest_result(
         write_replica(i + 1, new_wmin_pdf, wm_headers.encode("UTF-8"), wm_replica)
 
     # Generate central replica
+    log.info(f"Generating central replica for {new_wmin_pdf}")
+    generate_replica0(PDF(wmin_fit_name))

--- a/wmin/runcards/wmin_fit_runcards/wmin_analytic_dis.yaml
+++ b/wmin/runcards/wmin_fit_runcards/wmin_analytic_dis.yaml
@@ -1,0 +1,65 @@
+meta: 'An example of analytic fit using wmin paramterisation on reduced DIS dataset.'
+
+#######################
+# Data and theory specs
+#######################
+
+dataset_inputs:    
+  # DIS                
+  - {'dataset': 'NMC_NC_NOTFIXED_P_EM-SIGMARED', 'variant': 'legacy'}
+  - {'dataset': 'HERA_NC_318GEV_EM-SIGMARED', 'variant': 'legacy'} 
+  - {'dataset': 'HERA_NC_251GEV_EP-SIGMARED', 'variant': 'legacy'}
+  - {'dataset': 'HERA_NC_300GEV_EP-SIGMARED', 'variant': 'legacy'}
+
+
+theoryid: 40001000                          # The theory from which the predictions are drawn.
+use_cuts: internal                     # The kinematic cuts to be applied to the data.
+
+closure_test_level: 0                  # The closure test level: False for experimental, level 0
+                                       # for pseudodata with no noise, level 1 for pseudodata with
+                                       # noise.
+closure_test_pdf: NNPDF40_nnlo_as_01180 # The closure test PDF used if closure_level is not False
+
+
+#####################
+# Loss function specs
+#####################
+
+positivity:                            # Positivity datasets, used in the positivity penalty.
+  posdatasets:
+  - {dataset: POSF2U, maxlambda: 1e6}
+
+alpha: 1e-7                           
+lambda_positivity: 0                 
+
+use_fit_t0: True                       # Whether the t0 covariance is used in the chi2 loss.
+t0pdfset: NNPDF40_nnlo_as_01180         # The t0 PDF used to build the t0 covariance matrix.
+
+
+#############
+# Model specs
+#############
+wmin_settings:                         # Settings for the weight minimisation model
+  wminpdfset: NNPDF40_nnlo_as_01180     # PDF set from which the replicas are selected
+  n_basis: 10                          # Number of weights/replicas used in the fit
+
+
+
+###################
+# Methodology specs
+###################
+
+# Analytic settings
+analytic_settings:
+  n_posterior_samples: 10
+  full_sample_size: 1000
+  sampling_seed: 123456
+  optimal_prior: True
+
+prior_settings:
+  type: 'uniform_parameter_prior'            # The type of prior used in Nested Sampling (model dependent)
+  max_val: 10.0
+  min_val: -10.0
+
+actions_:
+- run_analytic_fit                        # Choose from ultranest_fit, monte_carlo_fit, analytic_fit

--- a/wmin/runcards/wmin_fit_runcards/wmin_bayes_dis.yaml
+++ b/wmin/runcards/wmin_fit_runcards/wmin_bayes_dis.yaml
@@ -12,7 +12,7 @@ dataset_inputs:
   - {'dataset': 'HERA_NC_300GEV_EP-SIGMARED', 'variant': 'legacy'}
 
 
-theoryid: 40001000                          # The theory from which the predictions are drawn.
+theoryid: 700                          # The theory from which the predictions are drawn.
 use_cuts: internal                     # The kinematic cuts to be applied to the data.
 
 closure_test_level: 0                  # The closure test level: False for experimental, level 0

--- a/wmin/runcards/wmin_fit_runcards/wmin_bayes_dis.yaml
+++ b/wmin/runcards/wmin_fit_runcards/wmin_bayes_dis.yaml
@@ -1,0 +1,75 @@
+meta: 'An example of a bayesian fit using wmin parameterisation on a reduced DIS dataset'
+
+#######################
+# Data and theory specs
+#######################
+
+dataset_inputs:    
+  # DIS                
+  - {'dataset': 'NMC_NC_NOTFIXED_P_EM-SIGMARED', 'variant': 'legacy'}
+  - {'dataset': 'HERA_NC_318GEV_EM-SIGMARED', 'variant': 'legacy'} 
+  - {'dataset': 'HERA_NC_251GEV_EP-SIGMARED', 'variant': 'legacy'}
+  - {'dataset': 'HERA_NC_300GEV_EP-SIGMARED', 'variant': 'legacy'}
+
+
+theoryid: 40001000                          # The theory from which the predictions are drawn.
+use_cuts: internal                     # The kinematic cuts to be applied to the data.
+
+closure_test_level: 0                  # The closure test level: False for experimental, level 0
+                                       # for pseudodata with no noise, level 1 for pseudodata with
+                                       # noise.
+closure_test_pdf: NNPDF40_nnlo_as_01180 # The closure test PDF used if closure_level is not False
+
+
+#####################
+# Loss function specs
+#####################
+
+positivity:                            # Positivity datasets, used in the positivity penalty.
+  posdatasets:
+  - {dataset: POSF2U, maxlambda: 1e6}
+
+positivity_penalty_settings:
+  positivity_penalty: False
+  alpha: 1e-7                           
+  lambda_positivity: 0             
+
+
+use_fit_t0: True                       # Whether the t0 covariance is used in the chi2 loss.
+t0pdfset: NNPDF40_nnlo_as_01180         # The t0 PDF used to build the t0 covariance matrix.
+
+
+#############
+# Model specs
+#############
+
+# Weight minimisation settings
+wmin_settings:
+  wminpdfset: NNPDF40_nnlo_as_01180
+  n_basis: 10
+  wmin_inherited_evolution: true
+
+###################
+# Methodology specs
+###################
+
+# Nested Sampling settings
+
+ns_settings:
+  sampler_plot: True # is slow for large number of parameters
+  n_posterior_samples: 10
+  ReactiveNS_settings:
+    vectorized: False
+    ndraw_max: 500
+  Run_settings:
+    min_num_live_points: 500
+    min_ess: 50
+    frac_remain: 0.01
+
+prior_settings:
+  type: 'uniform_parameter_prior'            # The type of prior used in Nested Sampling (model dependent)
+  max_val: 10.0
+  min_val: -10.0
+
+actions_:
+- run_ultranest_fit                       

--- a/wmin/runcards/wmin_fit_runcards/wmin_mc_dis.yaml
+++ b/wmin/runcards/wmin_fit_runcards/wmin_mc_dis.yaml
@@ -1,0 +1,63 @@
+meta: 'An example of Monte Carlo fit, using wmin parameterisation, on a reduced DIS dataset.'
+
+#######################
+# Data and theory specs
+#######################
+
+dataset_inputs:    
+  # DIS                
+  - {'dataset': 'NMC_NC_NOTFIXED_P_EM-SIGMARED', 'variant': 'legacy'}
+  - {'dataset': 'HERA_NC_318GEV_EM-SIGMARED', 'variant': 'legacy'} 
+  - {'dataset': 'HERA_NC_251GEV_EP-SIGMARED', 'variant': 'legacy'}
+  - {'dataset': 'HERA_NC_300GEV_EP-SIGMARED', 'variant': 'legacy'}
+
+
+
+theoryid: 40001000                          # The theory from which the predictions are drawn.
+use_cuts: internal                     # The kinematic cuts to be applied to the data.
+
+closure_test_level: 0                  # The closure test level: False for experimental, level 0
+                                       # for pseudodata with no noise, level 1 for pseudodata with
+                                       # noise.
+closure_test_pdf: NNPDF40_nnlo_as_01180 # The closure test PDF used if closure_level is not False
+
+
+#####################
+# Loss function specs
+#####################
+
+positivity:                            # Positivity datasets, used in the positivity penalty.
+  posdatasets:
+  - {dataset: POSF2U, maxlambda: 1e6}
+
+alpha: 1e-7                           
+lambda_positivity: 0                 
+
+use_fit_t0: True                       # Whether the t0 covariance is used in the chi2 loss.
+t0pdfset: NNPDF40_nnlo_as_01180         # The t0 PDF used to build the t0 covariance matrix.
+
+
+#############
+# Model specs
+#############
+wmin_settings:                         # Settings for the weight minimisation model
+  wminpdfset: NNPDF40_nnlo_as_01180     # PDF set from which the replicas are selected
+  n_basis: 10                          # Number of weights/replicas used in the fit
+
+
+###################
+# Methodology specs
+###################
+
+# Monte Carlo settings
+use_gen_t0: True                       # Whether the t0 covariance is used to generated pseudodata.
+max_epochs: 1000                       # The max number of epochs in Monte Carlo training.
+mc_validation_fraction: 0.0            # The fraction of the data used for validation in Monte Carlo training.
+mc_initialiser_settings:               # The initialiser for Monte Carlo training.
+  type: uniform                        # This setting starts with all parameters equal to zero.
+  min_val: -1
+  max_val: 1
+  random_seed: 0
+
+actions_:
+- run_monte_carlo_fit                        # Choose from ultranest_fit, monte_carlo_fit, analytic_fit

--- a/wmin/tests/test_config.py
+++ b/wmin/tests/test_config.py
@@ -7,11 +7,12 @@ from wmin.config import WminConfig
 from reportengine.configparser import ConfigError
 import unittest
 
+INPUT_PARAMS = {}
+CONFIG = WminConfig(INPUT_PARAMS)
+
 
 @patch("wmin.config.log.warning")
 def test_parse_wmin_settings_valid(mock_log_warning):
-    input_params = {}
-    config = WminConfig(input_params)
 
     settings = {
         "n_basis": 10,
@@ -25,15 +26,13 @@ def test_parse_wmin_settings_valid(mock_log_warning):
         "wmin_inherited_evolution": True,
     }
 
-    result = config.parse_wmin_settings(settings)
+    result = CONFIG.parse_wmin_settings(settings)
     assert result == expected
     mock_log_warning.assert_not_called()
 
 
 @patch("wmin.config.log.warning")
 def test_parse_wmin_settings_missing_n_basis(mock_log_warning):
-    input_params = {}
-    config = WminConfig(input_params)
 
     settings = {
         "wminpdfset": "PDF",
@@ -41,15 +40,13 @@ def test_parse_wmin_settings_missing_n_basis(mock_log_warning):
     }
 
     with unittest.TestCase().assertRaises(ValueError) as context:
-        config.parse_wmin_settings(settings)
+        CONFIG.parse_wmin_settings(settings)
     assert str(context.exception) == "Missing key n_basis for wmin_settings"
     mock_log_warning.assert_not_called()
 
 
 @patch("wmin.config.log.warning")
 def test_parse_wmin_settings_missing_wminpdfset(mock_log_warning):
-    input_params = {}
-    config = WminConfig(input_params)
 
     settings = {
         "n_basis": 10,
@@ -57,15 +54,13 @@ def test_parse_wmin_settings_missing_wminpdfset(mock_log_warning):
     }
 
     with unittest.TestCase().assertRaises(ValueError) as context:
-        config.parse_wmin_settings(settings)
+        CONFIG.parse_wmin_settings(settings)
     assert str(context.exception) == "Missing key wminpdfset for wmin_settings"
     mock_log_warning.assert_not_called()
 
 
 @patch("wmin.config.log.warning")
 def test_parse_wmin_settings_with_unknown_key(mock_log_warning):
-    input_params = {}
-    config = WminConfig(input_params)
 
     settings = {
         "n_basis": 10,
@@ -80,9 +75,44 @@ def test_parse_wmin_settings_with_unknown_key(mock_log_warning):
         "wmin_inherited_evolution": True,
     }
 
-    result = config.parse_wmin_settings(settings)
+    result = CONFIG.parse_wmin_settings(settings)
     assert result == expected
     mock_log_warning.assert_called_once()
     args, kwargs = mock_log_warning.call_args
     assert isinstance(args[0], ConfigError)
     assert "Key 'unknown_key' in ns_settings not known." in str(args[0])
+
+
+def test_parse_prior_settings_valid_uniform_with_min_max():
+    settings = {"type": "uniform_parameter_prior", "min_val": -5, "max_val": 10}
+
+    expected = {"type": "uniform_parameter_prior", "min_val": -5, "max_val": 10}
+
+    result = CONFIG.parse_prior_settings(settings)
+    assert result == expected
+
+
+def test_parse_prior_settings_valid_uniform_default_min_max():
+    settings = {"type": "uniform_parameter_prior"}
+
+    expected = {"type": "uniform_parameter_prior", "min_val": -1, "max_val": 1}
+
+    result = CONFIG.parse_prior_settings(settings)
+    assert result == expected
+
+
+def test_parse_prior_settings_missing_type():
+    settings = {"min_val": -5, "max_val": 10}
+
+    with unittest.TestCase().assertRaises(ValueError) as context:
+        CONFIG.parse_prior_settings(settings)
+    assert str(context.exception) == "Missing key type for prior_settings"
+
+
+def test_parse_prior_settings_non_uniform_type():
+    settings = {"type": "non_uniform_type"}
+
+    expected = {"type": "non_uniform_type"}
+
+    result = CONFIG.parse_prior_settings(settings)
+    assert result == expected  # Non-uniform types should remain unmodified

--- a/wmin/tests/test_config.py
+++ b/wmin/tests/test_config.py
@@ -1,0 +1,88 @@
+"""
+Module for tests of the wmin.config module.
+"""
+
+from unittest.mock import patch
+from wmin.config import WminConfig
+from reportengine.configparser import ConfigError
+import unittest
+
+
+@patch("wmin.config.log.warning")
+def test_parse_wmin_settings_valid(mock_log_warning):
+    input_params = {}
+    config = WminConfig(input_params)
+
+    settings = {
+        "n_basis": 10,
+        "wminpdfset": "PDF",
+        "wmin_inherited_evolution": True,
+    }
+
+    expected = {
+        "n_basis": 10,
+        "wminpdfset": "PDF",
+        "wmin_inherited_evolution": True,
+    }
+
+    result = config.parse_wmin_settings(settings)
+    assert result == expected
+    mock_log_warning.assert_not_called()
+
+
+@patch("wmin.config.log.warning")
+def test_parse_wmin_settings_missing_n_basis(mock_log_warning):
+    input_params = {}
+    config = WminConfig(input_params)
+
+    settings = {
+        "wminpdfset": "PDF",
+        "wmin_inherited_evolution": True,
+    }
+
+    with unittest.TestCase().assertRaises(ValueError) as context:
+        config.parse_wmin_settings(settings)
+    assert str(context.exception) == "Missing key n_basis for wmin_settings"
+    mock_log_warning.assert_not_called()
+
+
+@patch("wmin.config.log.warning")
+def test_parse_wmin_settings_missing_wminpdfset(mock_log_warning):
+    input_params = {}
+    config = WminConfig(input_params)
+
+    settings = {
+        "n_basis": 10,
+        "wmin_inherited_evolution": True,
+    }
+
+    with unittest.TestCase().assertRaises(ValueError) as context:
+        config.parse_wmin_settings(settings)
+    assert str(context.exception) == "Missing key wminpdfset for wmin_settings"
+    mock_log_warning.assert_not_called()
+
+
+@patch("wmin.config.log.warning")
+def test_parse_wmin_settings_with_unknown_key(mock_log_warning):
+    input_params = {}
+    config = WminConfig(input_params)
+
+    settings = {
+        "n_basis": 10,
+        "wminpdfset": "PDF",
+        "wmin_inherited_evolution": True,
+        "unknown_key": "value",
+    }
+
+    expected = {
+        "n_basis": 10,
+        "wminpdfset": "PDF",
+        "wmin_inherited_evolution": True,
+    }
+
+    result = config.parse_wmin_settings(settings)
+    assert result == expected
+    mock_log_warning.assert_called_once()
+    args, kwargs = mock_log_warning.call_args
+    assert isinstance(args[0], ConfigError)
+    assert "Key 'unknown_key' in ns_settings not known." in str(args[0])

--- a/wmin/tests/test_export_results.py
+++ b/wmin/tests/test_export_results.py
@@ -1,0 +1,166 @@
+from unittest.mock import patch, mock_open, MagicMock
+import numpy as np
+import os
+import pathlib
+
+# Assuming these functions are imported from the module
+from wmin.export_results import (
+    write_wmin_combined_replicas,
+    write_new_lhapdf_info_file_from_previous_pdf,
+    write_lhapdf_from_ultranest_result,
+)
+
+
+import numpy as np
+import pandas as pd
+import tempfile
+import os
+from unittest import mock
+import pathlib
+
+
+@mock.patch("wmin.export_results.write_replica")
+@mock.patch("wmin.export_results.log.info")
+def test_write_wmin_combined_replicas(mock_log_info, mock_write_replica):
+    # Create mock wmin_parameters array
+    wmin_parameters = np.array([[0.2, 0.3, 0.5], [0.4, 0.4, 0.2]])
+
+    # Create a mock replicas DataFrame
+    data = {1: [0.5, 0.6], 2: [0.7, 0.8], 3: [0.9, 1.0], 4: [1.1, 1.2]}
+    replicas_df = pd.DataFrame(data)
+
+    # Temporary path for new_wmin_pdf
+    with tempfile.TemporaryDirectory() as tmpdir:
+        new_wmin_pdf = pathlib.Path(os.path.join(tmpdir, "wmin_pdf"))
+
+        # Call the function being tested
+        write_wmin_combined_replicas(wmin_parameters, replicas_df, new_wmin_pdf)
+
+        # Check that log.info was called twice (since there are 2 wmin_parameter sets)
+        assert mock_log_info.call_count == 2
+
+        # Check that write_replica was called twice (once for each wmin_parameter set)
+        assert mock_write_replica.call_count == 2
+
+        # Check the arguments passed to write_replica
+        call_args = mock_write_replica.call_args_list
+        assert call_args[0][0][0] == 1  # Replica number 1
+        assert call_args[1][0][0] == 2  # Replica number 2
+        assert call_args[0][0][1] == new_wmin_pdf  # File path for new_wmin_pdf
+
+        # Validate headers
+        assert "PdfType: replica" in call_args[0][0][2].decode("utf-8")
+        assert "FromMCReplica: 0" in call_args[0][0][2].decode("utf-8")
+        assert "FromMCReplica: 1" in call_args[1][0][2].decode("utf-8")
+
+
+# Mock the log.info call
+@mock.patch("wmin.export_results.log.info")
+def test_write_new_lhapdf_info_file_from_previous_pdf(mock_log_info):
+    # Set up mock inputs
+    name_old_pdfset = pathlib.Path("old_pdfset")
+    name_new_pdfset = pathlib.Path("new_pdfset")
+    num_members = 50
+    description_set = "New Description"
+    errortype = "custom_error"
+
+    # Simulate old info file content
+    old_info_content = """SetDesc: "Old Description"
+NumMembers: 100
+ErrorType: replicas
+OtherInfo: "Some other details"
+"""
+
+    # Temporary directories to simulate old and new pdf sets
+    with tempfile.TemporaryDirectory() as temp_old_dir, tempfile.TemporaryDirectory() as temp_new_dir:
+        path_old_pdfset = pathlib.Path(temp_old_dir)
+        path_new_pdfset = pathlib.Path(temp_new_dir)
+
+        # Create a mock old info file
+        old_info_file = pathlib.Path(
+            os.path.join(path_old_pdfset, f"{name_old_pdfset}.info")
+        )
+        with open(old_info_file, "w") as f:
+            f.write(old_info_content)
+
+        # Call the function being tested
+        write_new_lhapdf_info_file_from_previous_pdf(
+            path_old_pdfset,
+            name_old_pdfset,
+            path_new_pdfset,
+            name_new_pdfset,
+            num_members,
+            description_set,
+            errortype,
+        )
+
+        # Verify that the new info file was created with correct content
+        new_info_file = os.path.join(path_new_pdfset, f"{name_new_pdfset}.info")
+        assert os.path.exists(new_info_file)
+
+        with open(new_info_file, "r") as f:
+            new_info_content = f.read()
+
+        # Check that the updated fields are correct
+        assert 'SetDesc: f"New Description"\n' in new_info_content
+        assert f"NumMembers: {num_members}\n" in new_info_content
+        assert f"ErrorType: {errortype}\n" in new_info_content
+        assert (
+            'OtherInfo: "Some other details"\n' in new_info_content
+        )  # Unchanged content
+
+        # Ensure that the log.info call was made with the correct message
+        mock_log_info.assert_called_once_with(
+            f"Info file written to {os.path.join(path_new_pdfset, f'{name_new_pdfset}.info')}"
+        )
+
+
+@patch("wmin.export_results.load_all_replicas")
+@patch("wmin.export_results.rep_matrix")
+@patch("wmin.export_results.write_replica")
+@patch("wmin.export_results.generate_replica0")
+@patch("os.makedirs")
+@patch("pathlib.Path.exists", return_value=False)
+@patch("wmin.export_results.lhapdf.paths")
+@patch("wmin.export_results.PDF")
+@patch("wmin.export_results.write_wmin_combined_replicas")
+@patch("wmin.export_results.write_new_lhapdf_info_file_from_previous_pdf")
+def test_write_lhapdf_from_ultranest_result(
+    mock_write_info,
+    mock_write_combined,
+    mock_pdf,
+    mock_lhapdf_paths,
+    mock_path_exists,
+    mock_makedirs,
+    mock_generate_replica0,
+    mock_write_replica,
+    mock_rep_matrix,
+    mock_load_all_replicas,
+):
+    # Setup mocks
+    mock_pdf.return_value = "MockPDF"
+    mock_lhapdf_paths.return_value = ["/path/to/lhapdf"]
+
+    wmin_settings = {"wminpdfset": "MockPDF"}
+    ultranest_fit = MagicMock()
+    ultranest_fit.resampled_posterior = np.array(
+        [[0.1, 0.2], [0.3, 0.4]]
+    )  # Mock ultranest fit
+
+    ns_settings = {"n_posterior_samples": 2}
+    output_path = "/output/path"
+    errortype = "replicas"
+
+    mock_load_all_replicas.return_value = (["header1"], np.random.rand(5, 5))
+    mock_rep_matrix.return_value = MagicMock()
+
+    # Call the function
+    write_lhapdf_from_ultranest_result(
+        wmin_settings, ultranest_fit, ns_settings, output_path, errortype
+    )
+
+    mock_write_info.assert_called_once()  # Ensure the info file function was called
+    mock_write_combined.assert_called_once()  # Ensure the combined replica function was called
+    mock_generate_replica0.assert_called_once_with(
+        "MockPDF"
+    )  # Ensure central replica generation

--- a/wmin/tests/test_ultranest_fit.py
+++ b/wmin/tests/test_ultranest_fit.py
@@ -1,0 +1,79 @@
+from unittest import mock
+from wmin.ultranest_fit import run_ultranest_fit
+
+
+# Test when wmin_inherited_evolution is True
+@mock.patch("wmin.ultranest_fit.write_lhapdf_from_ultranest_result")
+def test_run_ultranest_fit_inherited_evolution(mock_write_lhapdf):
+    # Set up mock inputs
+    ultranest_fit = mock.Mock()  # Mock the ultranest_fit object
+    output_path = mock.Mock()  # Mock the output_path (pathlib.PosixPath)
+    pdf_model = mock.Mock()  # Mock the pdf_model
+    wmin_settings = {
+        "wmin_inherited_evolution": True
+    }  # wmin_inherited_evolution is True
+    ns_settings = {"some_ns_setting": 1}
+    errortype = "replicas"
+
+    # Call the function being tested
+    run_ultranest_fit(
+        ultranest_fit,
+        output_path,
+        pdf_model,
+        wmin_settings,
+        ns_settings,
+        errortype,
+    )
+
+    # Verify that write_lhapdf_from_ultranest_result is called with correct arguments
+    mock_write_lhapdf.assert_called_once_with(
+        wmin_settings, ultranest_fit, ns_settings, output_path, errortype
+    )
+
+
+# Test when wmin_inherited_evolution is False
+@mock.patch("colibri.ultranest_fit.run_ultranest_fit")
+def test_run_ultranest_fit_no_inherited_evolution(mock_colibri_run):
+    # Set up mock inputs
+    ultranest_fit = mock.Mock()  # Mock the ultranest_fit object
+    output_path = mock.Mock()  # Mock the output_path (pathlib.PosixPath)
+    pdf_model = mock.Mock()  # Mock the pdf_model
+    wmin_settings = {
+        "wmin_inherited_evolution": False
+    }  # wmin_inherited_evolution is False
+    ns_settings = {"some_ns_setting": 1}
+    errortype = "replicas"
+
+    # Call the function being tested
+    run_ultranest_fit(
+        ultranest_fit,
+        output_path,
+        pdf_model,
+        wmin_settings,
+        ns_settings,
+        errortype,
+    )
+
+    # Verify that colibri's run_ultranest_fit is called with correct arguments
+    mock_colibri_run.assert_called_once_with(ultranest_fit, output_path, pdf_model)
+
+
+# Test default behavior for errortype
+@mock.patch("wmin.ultranest_fit.write_lhapdf_from_ultranest_result")
+def test_run_ultranest_fit_default_errortype(mock_write_lhapdf):
+    # Set up mock inputs
+    ultranest_fit = mock.Mock()  # Mock the ultranest_fit object
+    output_path = mock.Mock()  # Mock the output_path (pathlib.PosixPath)
+    pdf_model = mock.Mock()  # Mock the pdf_model
+    wmin_settings = {
+        "wmin_inherited_evolution": True
+    }  # wmin_inherited_evolution is True
+    ns_settings = {"some_ns_setting": 1}
+
+    # Call the function without providing an errortype (it should use the default "replicas")
+    run_ultranest_fit(ultranest_fit, output_path, pdf_model, wmin_settings, ns_settings)
+
+    # Verify that write_lhapdf_from_ultranest_result is called with the default "replicas" errortype
+    mock_write_lhapdf.assert_called_once_with(
+        wmin_settings, ultranest_fit, ns_settings, output_path, "replicas"
+    )

--- a/wmin/ultranest_fit.py
+++ b/wmin/ultranest_fit.py
@@ -1,0 +1,34 @@
+"""
+wmin.ultranest_fit.py
+
+This module allows to override some of the functions defined in colibri.ultranest_fit.py if necessary.
+"""
+
+
+def run_ultranest_fit(
+    ultranest_fit, output_path, pdf_model, wmin_inherited_evolution=False
+):
+    """
+    Overrides the run_ultranest_fit function in colibri.ultranest_fit.py.
+    It allows to export the results of an Ultranest fit in such a way that no evolution is
+    needed on the fitted wmin set once the fit has run. Evolution is directly inherited from
+    the basis that was used in the fit.
+
+    Parameters
+    ----------
+    ultranest_fit: UltranestFit
+        The results of the Ultranest fit.
+    output_path: pathlib.PosixPath
+        Path to the output folder.
+    pdf_model: pdf_model.PDFModel
+        The PDF model used in the fit.
+    wmin_inherited_evolution: bool
+        If True, the evolution of the wmin set is inherited from the basis used
+    """
+    if wmin_inherited_evolution:
+        pass
+    else:
+        # import here to avoid problems with duplicated names
+        from colibri.ultranest_fit import run_ultranest_fit
+
+        return run_ultranest_fit(ultranest_fit, output_path, pdf_model)

--- a/wmin/ultranest_fit.py
+++ b/wmin/ultranest_fit.py
@@ -36,11 +36,10 @@ def run_ultranest_fit(
     errortype: str
         The type of error to be calculated. Default is "replicas".
     """
-    wminpdfset = wmin_settings["wminpdfset"]
 
     if wmin_settings["wmin_inherited_evolution"]:
         write_lhapdf_from_ultranest_result(
-            wminpdfset,
+            wmin_settings,
             ultranest_fit,
             ns_settings,
             output_path,

--- a/wmin/ultranest_fit.py
+++ b/wmin/ultranest_fit.py
@@ -4,9 +4,17 @@ wmin.ultranest_fit.py
 This module allows to override some of the functions defined in colibri.ultranest_fit.py if necessary.
 """
 
+from wmin.export_results import write_lhapdf_from_ultranest_result
+
 
 def run_ultranest_fit(
-    ultranest_fit, output_path, pdf_model, wmin_inherited_evolution=False
+    ultranest_fit,
+    output_path,
+    pdf_model,
+    wmin_inherited_evolution,
+    wmin_settings,
+    ns_settings,
+    errortype="replicas",
 ):
     """
     Overrides the run_ultranest_fit function in colibri.ultranest_fit.py.
@@ -25,8 +33,15 @@ def run_ultranest_fit(
     wmin_inherited_evolution: bool
         If True, the evolution of the wmin set is inherited from the basis used
     """
+    wminpdfset = wmin_settings["wminpdfset"]
     if wmin_inherited_evolution:
-        pass
+        write_lhapdf_from_ultranest_result(
+            wminpdfset,
+            ultranest_fit,
+            ns_settings,
+            output_path,
+            errortype,
+        )
     else:
         # import here to avoid problems with duplicated names
         from colibri.ultranest_fit import run_ultranest_fit

--- a/wmin/ultranest_fit.py
+++ b/wmin/ultranest_fit.py
@@ -29,8 +29,12 @@ def run_ultranest_fit(
         Path to the output folder.
     pdf_model: pdf_model.PDFModel
         The PDF model used in the fit.
-    wmin_inherited_evolution: bool
-        If True, the evolution of the wmin set is inherited from the basis used
+    wmin_settings: dict
+        Dictionary containing the wmin settings.
+    ns_settings: dict
+        Dictionary containing the settings for the nested sampling fit.
+    errortype: str
+        The type of error to be calculated. Default is "replicas".
     """
     wminpdfset = wmin_settings["wminpdfset"]
 

--- a/wmin/ultranest_fit.py
+++ b/wmin/ultranest_fit.py
@@ -11,7 +11,6 @@ def run_ultranest_fit(
     ultranest_fit,
     output_path,
     pdf_model,
-    wmin_inherited_evolution,
     wmin_settings,
     ns_settings,
     errortype="replicas",
@@ -34,7 +33,8 @@ def run_ultranest_fit(
         If True, the evolution of the wmin set is inherited from the basis used
     """
     wminpdfset = wmin_settings["wminpdfset"]
-    if wmin_inherited_evolution:
+
+    if wmin_settings["wmin_inherited_evolution"]:
         write_lhapdf_from_ultranest_result(
             wminpdfset,
             ultranest_fit,


### PR DESCRIPTION
This pull request includes significant changes to the `wmin` module, focusing on adding new functionality for weight minimization fits, enhancing configuration parsing, and introducing comprehensive tests. The most important changes include the addition of new modules and methods for exporting fit results, updates to configuration parsing, and the introduction of new test cases.

### New Functionality:

* **Export Results Module:**
  * Added `wmin/export_results.py` to include functions for exporting fit results, such as `write_wmin_combined_replicas`, `write_new_lhapdf_info_file_from_previous_pdf`, and `write_lhapdf_from_ultranest_result`.

### Configuration Enhancements:

* **Configuration Parsing:**
  * Updated `wmin/config.py` to include logging and error handling for configuration parsing, and added new methods `parse_prior_settings` and `parse_wmin_settings` for better handling of prior and wmin settings. [[1]](diffhunk://#diff-52ee91bd381210874f21a09a426206532142241ff02fac3796f1f60e3716d2d0R11-R17) [[2]](diffhunk://#diff-52ee91bd381210874f21a09a426206532142241ff02fac3796f1f60e3716d2d0L25-R31) [[3]](diffhunk://#diff-52ee91bd381210874f21a09a426206532142241ff02fac3796f1f60e3716d2d0R46-R74)

### Testing:

* **New Test Cases:**
  * Added `wmin/tests/test_config.py` to include unit tests for the configuration parsing methods, ensuring robust error handling and correct parsing of settings.
  * Added `wmin/tests/test_export_results.py` to include unit tests for the new export results functions, ensuring they work as expected with mock data.

### Miscellaneous:

* **Runcards:**
  * Added example runcards for different fit methodologies (`wmin_analytic_dis.yaml`, `wmin_bayes_dis.yaml`, `wmin_mc_dis.yaml`) to demonstrate the usage of the new weight minimization settings. [[1]](diffhunk://#diff-9406745a8340107793394d1f4f4920fcb57ff5218e2c7c9f3cc63d0a23bf5a2bR1-R65) [[2]](diffhunk://#diff-72b22603f565fd5f097d02dd42732487f29c323f169b55abe46669f0e27fe4a8R1-R75) [[3]](diffhunk://#diff-a428aeb764d00813a49e381728ac4526bd9b185fc14fb7805506aa77320ac29cR1-R63)

### Minor Changes:

* **Module Import:**
  * Updated `wmin/app.py` to include the new `wmin.ultranest_fit` module.
  
  
  
##  Benchmark of the Inherited (wmin) evolution

Wmin Basis used for the test: `241002_NNDF40_basis_pca`
Run a fit using `wmin_bayes_dis.yaml` runcard with `wmin_inherited_evolution` once true and once false.
The fit with `wmin_inherited_evolution: false` is the evolved with `evolve_fit`

https://vp.nnpdf.science/zpmJkg-RTVOwFl4EoKM2xw==

